### PR TITLE
[Fix] common misspelling errors

### DIFF
--- a/clappy-bird-android/src/com/zoneigh/clappybird/model/AndroidClapListener.java
+++ b/clappy-bird-android/src/com/zoneigh/clappybird/model/AndroidClapListener.java
@@ -111,7 +111,7 @@ public class AndroidClapListener implements IClapListener {
             	return;
             }
                         	
-            // Successfull Read
+            // Successful Read
             double[] preRealData = new double[bufferSize];
             double PI = 3.14159265359;
             for (int i = 0; i < bufferSize; i++) {


### PR DESCRIPTION
For reference: https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines